### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/xtopdf/xtopdf/controllers/FileConversionController.java
+++ b/src/main/java/com/xtopdf/xtopdf/controllers/FileConversionController.java
@@ -22,13 +22,14 @@ public class FileConversionController {
 
      @PostMapping
      public ResponseEntity<String> convertFile (@RequestParam("inputFile") MultipartFile inputFile, @RequestParam("outputFile") String outputFile) {
-         var sanitizedOutputString = Paths.get(outputFile).normalize().toString();
-         if(!sanitizedOutputString.endsWith(".pdf")) {
-             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Missing parameter");
+         var baseDirectory = Paths.get("/safe/output/directory").normalize().toAbsolutePath();
+         var sanitizedOutputPath = baseDirectory.resolve(outputFile).normalize().toAbsolutePath();
+         if (!sanitizedOutputPath.startsWith(baseDirectory) || !sanitizedOutputPath.toString().endsWith(".pdf")) {
+             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid output file path");
          }
 
          try {
-            fileConversionService.convertFile(inputFile, sanitizedOutputString);
+            fileConversionService.convertFile(inputFile, sanitizedOutputPath.toString());
             return ResponseEntity.ok("File converted successfully");
          } catch (FileConversionException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Error with conversion");

--- a/src/test/java/com/xtopdf/xtopdf/controllers/FileConversionControllerTest.java
+++ b/src/test/java/com/xtopdf/xtopdf/controllers/FileConversionControllerTest.java
@@ -81,6 +81,6 @@ class FileConversionControllerTest {
                         .file(inputFile)
                     .param("outputFile", ""))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string("Missing parameter"));
+                .andExpect(content().string("Invalid output file path"));
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/jmillar0046/XToPDF/security/code-scanning/3](https://github.com/jmillar0046/XToPDF/security/code-scanning/3)

To fix the problem, we need to ensure that the `outputFile` path is contained within a specific directory and does not contain any path traversal sequences. We can achieve this by resolving the path against a base directory and checking that the resolved path starts with the base directory.

1. Define a base directory where all output files should be stored.
2. Resolve the `outputFile` path against the base directory.
3. Check that the resolved path starts with the base directory.
4. If the check fails, throw an exception or return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
